### PR TITLE
fix: correct behaviour when entity is placeable by multiple items

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ Date: 2023-01-09
     - Pathfinder retries failing which prevented traversal of land 1 tile wide.
     - Containers that were not completely emptied/picked up during deconstruction jobs would not be added as a new job in the chunk checks.
     - Constructrons taking small movement steps in jobs.
+    - Entities that could be placed by multiple different items will no longer request all items but only the first.
   Improvements:
     - Pathfinder will now search for the mainland and start building from a fairly close point rather than trying to path through the whole lake.
   Changed:

--- a/script/constructron.lua
+++ b/script/constructron.lua
@@ -174,7 +174,10 @@ me.process_entity = function(entity, build_type, queue)
     end
     -- ghosts
     if (build_type == "ghost") and not (entity.type == 'item-request-proxy') then
-        for _, item in ipairs(entity.ghost_prototype.items_to_place_this) do
+        local items_to_place = entity.ghost_prototype.items_to_place_this
+        if items_to_place and #items_to_place > 0 then
+            local item = items_to_place[1] -- bots will only ever use the first item from this list
+
             if me.check_item_allowed(item.name) then
                 queue_surface_key['required_items'][item.name] = (queue_surface_key['required_items'][item.name] or 0) + item.count
             end
@@ -208,7 +211,11 @@ me.process_entity = function(entity, build_type, queue)
     -- entity upgrades
     if build_type == "upgrade" then
         local target_entity = entity.get_upgrade_target()
-        for _, item in ipairs(target_entity.items_to_place_this) do
+        local items_to_place = target_entity.items_to_place_this
+
+        if items_to_place and #items_to_place > 0 then
+            local item = items_to_place[1] -- bots will only ever use the first item from this list
+
             if me.check_item_allowed(item.name) then
                 queue_surface_key['required_items'][item.name] = (queue_surface_key['required_items'][item.name] or 0) + item.count
             end

--- a/script/constructron.lua
+++ b/script/constructron.lua
@@ -175,7 +175,7 @@ me.process_entity = function(entity, build_type, queue)
     -- ghosts
     if (build_type == "ghost") and not (entity.type == 'item-request-proxy') then
         local items_to_place = entity.ghost_prototype.items_to_place_this
-        if items_to_place and #items_to_place > 0 then
+        if items_to_place and items_to_place[1] then
             local item = items_to_place[1] -- bots will only ever use the first item from this list
 
             if me.check_item_allowed(item.name) then
@@ -213,7 +213,7 @@ me.process_entity = function(entity, build_type, queue)
         local target_entity = entity.get_upgrade_target()
         local items_to_place = target_entity.items_to_place_this
 
-        if items_to_place and #items_to_place > 0 then
+        if items_to_place and items_to_place[1] then
             local item = items_to_place[1] -- bots will only ever use the first item from this list
 
             if me.check_item_allowed(item.name) then


### PR DESCRIPTION
Entity prototypes specify `placeable_by` which can be a table of each item that places this entity.
Construction bots will only ever use the first entry from this list so the old (bugged) behaviour of adding all items that could place an entity has been replaced by only using the first from the table.

see: https://lua-api.factorio.com/latest/LuaEntityPrototype.html#LuaEntityPrototype.items_to_place_this
and Klonan on discord: https://discord.com/channels/139677590393716737/306402592265732098/1061699033330106408