### PR TITLE
Fix case where job was indexed as a number when it should have been nil

### DIFF
--- a/script/command_functions.lua
+++ b/script/command_functions.lua
@@ -182,7 +182,7 @@ me.recall_ctrons = function()
             }
             for _, constructron in pairs(constructrons) do
                 local closest_station = ctron.get_closest_service_station(constructron)
-                pathfinder.init_path_request(constructron, closest_station.position, _) -- find path to station
+                pathfinder.init_path_request(constructron, closest_station.position, nil) -- find path to station
             end
         else
             game.print('No stations to recall Constructrons to on ' .. surface.name .. '.')


### PR DESCRIPTION
Original error when calling `/ctron reset all`

```
Error while running command "ctron": __Constructron-Continued__/script/pathfinder.lua:48: attempt to index local 'job' (a number value)
stack traceback:
    __Constructron-Continued__/script/pathfinder.lua:48: in function 'init_path_request'
    __Constructron-Continued__/script/command_functions.lua:185: in function 'recall_ctrons'
    __Constructron-Continued__/control.lua:115: in function '?'
    __Constructron-Continued__/control.lua:324: in function <__Constructron-Continued__/control.lua:317>
```