### PR TITLE
Constructron-Continued with dynamic bot counts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.76
+Date: 2023-10-06
+  Features:
+    - Added dynamic robot limit. Each constructron tries to request as many robots at its equipment grid allows
+---------------------------------------------------------------------------------------------------
 Version: 1.0.75
 Date: 2023-07-08
   Bugfixes:

--- a/control.lua
+++ b/control.lua
@@ -138,6 +138,7 @@ local ensure_globals = function()
     global.debug_toggle = settings.global["constructron-debug-enabled"].value
     global.job_start_delay = (settings.global["job-start-delay"].value * 60)
     global.desired_robot_count = settings.global["desired_robot_count"].value
+    global.dynamic_robot_count = settings.global["dynamic_robot_count"].value
     global.desired_robot_name = settings.global["desired_robot_name"].value
     global.entities_per_tick = settings.global["entities_per_tick"].value --[[@as uint]]
     global.clear_robots_when_idle = settings.global["clear_robots_when_idle"].value --[[@as boolean]]
@@ -217,6 +218,8 @@ script.on_event(ev.on_runtime_mod_setting_changed, function(event)
         global.clear_robots_when_idle = settings.global["clear_robots_when_idle"].value --[[@as boolean]]
     elseif setting == "horde_mode" then
         global.horde_mode = settings.global["horde_mode"].value
+    elseif setting == "dynamic_robot_count" then
+        global.dynamic_robot_count = settings.global["dynamic_robot_count"].value
     end
 end)
 

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Constructron-Continued",
-  "version": "1.0.75",
+  "version": "1.0.76",
   "title": "Constructron-Continued",
   "author": "ILLISIS",
   "homepage": "https://github.com/ILLISIS/Constructron-continued/",

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -29,6 +29,7 @@ enable_rocket_powered_constructron=Enable rocket powered constructron
 entities_per_tick=entities processed per tick
 clear_robots_when_idle=Clear robots when idling
 horde_mode=Horde Mode
+dynamic_robot_count=Dynamic Robot Count
 
 [mod-setting-description]
 constructron-debug-enabled=Show debug information.
@@ -48,3 +49,4 @@ enable_rocket_powered_constructron=SE specific setting, only relevant for se-spa
 entities_per_tick=entities processed per tick
 clear_robots_when_idle=Clears robots from inventory when not on a job and rerequests them at the start of a job
 horde_mode=Utilize more Constructrons by avoiding job proximity merging.
+dynamic_robot_count=Get the maximum robot count from equipmentgrid instead of the given limit

--- a/script/command_functions.lua
+++ b/script/command_functions.lua
@@ -16,6 +16,7 @@ me.reset_settings = function()
     settings.global["clear_robots_when_idle"] = {value = false}
     settings.global["job-start-delay"] = {value = 5}
     settings.global["horde_mode"] = {value = false}
+    settings.global["dynamic_robot_count"] = {value = true}
 end
 
 me.clear_queues = function()

--- a/script/constructron.lua
+++ b/script/constructron.lua
@@ -744,9 +744,9 @@ end
 ---@return integer
 ctron.get_max_robot_count = function (grid)
     total_robot_limit = 0
-    for eq in grid.equipment do
+    for _, eq in pairs(grid.equipment) do
         if eq.type == 'roboport-equipment' then
-            total_robot_limit = total_robot_limit + eq.robot_limit
+            total_robot_limit = total_robot_limit + eq.prototype.logistic_parameters.robot_limit
         end
     end
     return total_robot_limit

--- a/script/constructron.lua
+++ b/script/constructron.lua
@@ -77,7 +77,11 @@ ctron.actions = {
             end
             -- ensure robots are in the inventory
             if game.item_prototypes[global.desired_robot_name] then
-                merged_items[global.desired_robot_name] = global.desired_robot_count
+                if global.dynamic_robot_count then
+                    merged_items[global.desired_robot_name] = ctron.get_max_robot_count(constructron.grid)
+                else
+                    merged_items[global.desired_robot_name] = global.desired_robot_count
+                end
             else
                 settings.global["desired_robot_name"] = {value = "construction-robot"}
                 global.desired_robot_name = "construction-robot"
@@ -734,6 +738,18 @@ ctron.paint_constructron = function(constructron, color_state)
     elseif color_state == 'repair' then
         constructron.color = color_lib.colors.charcoal
     end
+end
+
+---@param grid LuaEquipmentGrid
+---@return integer
+ctron.get_max_robot_count = function (grid)
+    total_robot_limit = 0
+    for eq in grid.equipment do
+        if eq.type == 'roboport-equipment' then
+            total_robot_limit = total_robot_limit + eq.robot_limit
+        end
+    end
+    return total_robot_limit
 end
 
 return ctron

--- a/settings.lua
+++ b/settings.lua
@@ -92,5 +92,11 @@ data:extend({
         order = "a11",
         setting_type = "runtime-global",
         default_value = false
+    }, {
+        type = "bool-setting",
+        name = "dynamic_robot_count",
+        order = "a12",
+        setting_type = "runtime-global",
+        default_value = false
     }
 })

--- a/settings.lua
+++ b/settings.lua
@@ -97,6 +97,6 @@ data:extend({
         name = "dynamic_robot_count",
         order = "a12",
         setting_type = "runtime-global",
-        default_value = false
+        default_value = true
     }
 })


### PR DESCRIPTION
This PR contains code that add's support for dynamic bot amount.

What does it mean? 
It adds a setting to the mod, which allows you to enable or disable this feature (on by default)
It adds a bit of code that manages to get the total size of roboports from the equipment grid, and requests X many bots (Total amount supported by the equipment together).

This way users aren't limited to the setting that sets the amount of requested bots.

With this feature all constructrons will try and use as many bots as their equipment allows.
also makes it easier to use different personal roboports, and 

Mod support?
supports other mods that add personal-roboports.

What tests have been run?
I've tested this new code with a roboport (modded) that can handle 500 robots, the construtron requests 500 robots.

Locale?
Sadly only managed to add english!