### PR TITLE
Fixed Py big buildings blocking

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,11 +7,13 @@ Date: 2023-10-31
     - Completely overhauled the job operation code.
     - Aligned the Constructron collision mask to the Spidertron which allows Constructrons to path through shallow water.
     - [SE] Added event handler for teleportation of Constructrons and Stations.
+    - [PY] Scaled up Constructrons if Alien Life is installed, so they don't get stuck on the Reproductive Complex.
   Bugfixes:
     - Fixed managed surfaces not being repopulated when performing the reset command.
     - Fixed infamous line 285 crash during deconstruction processing of modded entities that did not return a product upon mining the entity.
     - Fixed Constructrons getting stuck while building long trains.
     - Fixed request / inventory overload.
+    - Fixed items-on-ground not being actioned upon being marked for deconstruction due to legacy code.
   Other:
     - Removed clear robots setting as this is now done by default.
 ---------------------------------------------------------------------------------------------------

--- a/data/constructron.lua
+++ b/data/constructron.lua
@@ -36,7 +36,7 @@ local constructron_leg_definition = {
 }
 
 if mods["pyalienlife"] then
-    constructron_definition["scale"] = 1.75
+    constructron_definition["leg_scale"] = 1.75
     constructron_leg_definition["scale"] = 1.75
 end
 

--- a/data/constructron.lua
+++ b/data/constructron.lua
@@ -35,6 +35,11 @@ local constructron_leg_definition = {
     collision_mask = constructron_leg_collision_mask
 }
 
+if mods["pyalienlife"] then
+    constructron_definition["scale"] = 1.75
+    constructron_leg_definition["scale"] = 1.75
+end
+
 local constructron = lib_spider.create_spidertron(constructron_definition)
 
 local leg_entities = lib_spider.create_spidertron_legs(constructron_leg_definition)


### PR DESCRIPTION
If Alien Life with the problematic Reproductive Complex is installed, scale up Constructrons by 75% so that they can walk over the huge building.