### PR TITLE
Add ghost removal detection.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ Date: 2023-10-31
     - Implemented a custom pathfinder to augment the games pathfinder for landfill jobs.
   Changes:
     - Completely overhauled the job operation code.
+    - Added detection of ghost deconstruction with adjustment of logistic requests.
     - Aligned the Constructron collision mask to the Spidertron which allows Constructrons to path through shallow water.
     - [SE] Added event handler for teleportation of Constructrons and Stations.
   Bugfixes:
@@ -12,7 +13,7 @@ Date: 2023-10-31
     - Fixed infamous line 285 crash during deconstruction processing of modded entities that did not return a product upon mining the entity.
     - Fixed Constructrons getting stuck while building long trains.
     - Fixed request / inventory overload.
-    - Fixed items-on-ground not being actioned upon being market for deconstruction due to legacy code.
+    - Fixed items-on-ground not being actioned upon being marked for deconstruction due to legacy code.
   Other:
     - Removed clear robots setting as this is now done by default.
 ---------------------------------------------------------------------------------------------------

--- a/control.lua
+++ b/control.lua
@@ -66,6 +66,7 @@ local ensure_globals = function()
     --
     global.job_index = global.job_index or 0
     global.jobs = global.jobs or {}
+    global.unit_jobs = global.unit_jobs or {}
     --
     global.construction_index = global.construction_index or 0
     global.deconstruction_index = global.deconstruction_index or 0
@@ -273,6 +274,7 @@ local function reset(player, parameters)
         -- Clear jobs/queues/entities
         global.jobs = {}
         global.job_index = 0
+        global.unit_jobs = {}
         cmd.clear_queues()
         -- Clear supporting globals
         global.stack_cache = {}
@@ -312,6 +314,7 @@ local function clear(player, parameters)
         cmd.reload_ctron_color()
         global.jobs = {}
         global.job_index = 0
+        global.unit_jobs = {}
         cmd.recall_ctrons()
         cmd.reload_entities() -- needed to reset roboport construction radius
     elseif parameters[1] == "queues" then

--- a/migrations/Constructron-Continued_1.1.0.lua
+++ b/migrations/Constructron-Continued_1.1.0.lua
@@ -8,6 +8,7 @@ game.print('Reset all parameters and queues complete.')
 -- Clear jobs/queues/entities
 global.jobs = {}
 global.job_index = 0
+global.unit_jobs = {}
 cmd.clear_queues()
 -- Clear supporting globals
 global.stack_cache = {}


### PR DESCRIPTION
When a ghost is undone, deconstructed, or mined by the player, and the appropriate constructron is still waiting for items, adjust the logistic requests for the removed buildings. Once the constructron fills and starts moving, nothing is touched.