### PR TITLE
added dynamic way to add custom constructron

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -41,6 +41,29 @@ end))
 
 local ensure_storages = function()
     storage.constructron_names = storage.constructron_names or { ["constructron"] = true, ["constructron-rocket-powered"] = true}
+    storage.flying_constructrons = storage.flying_constructrons or { ["constructron-rocket-powered"] = true }
+    
+    -- Dynamically add custom constructron if configured
+    local custom_bases_string = settings.startup["custom-constructron-base"].value
+    if custom_bases_string and custom_bases_string ~= "" then
+        for custom_base_name in string.gmatch(custom_bases_string, '([^,]+)') do
+            custom_base_name = custom_base_name:match("^%s*(.-)%s*$") -- Trim whitespace
+            if custom_base_name and custom_base_name ~= "" then
+                local custom_ctron_name = custom_base_name .. "-constructron"
+                storage.constructron_names[custom_ctron_name] = true
+                
+                -- Check if this custom constructron flies (no water collision)
+                local proto = prototypes.entity[custom_ctron_name]
+                if proto then
+                    local layers = proto.collision_mask and (proto.collision_mask.layers or proto.collision_mask) or {}
+                    if not layers["water_tile"] then
+                        storage.flying_constructrons[custom_ctron_name] = true
+                    end
+                end
+            end
+        end
+    end
+
     storage.station_names = storage.station_names or { ["service_station"] = true }
     --
     storage.registered_entities = storage.registered_entities or {}
@@ -320,9 +343,6 @@ script.on_configuration_changed(init)
 --===========================================================================--
 
 local ev = defines.events
-
--- script.on_event(ev.on_player_used_spidertron_remote, function(event)
--- end)
 
 local research_handlers = {
     ["stronger-explosives-3"] = function()

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,2 +1,79 @@
 require("data/roboports")
 require("data/constructron_pathing_proxy")
+
+-- Custom Constructron Logic (Supports comma-separated list)
+local custom_bases_string = settings.startup["custom-constructron-base"].value
+
+if custom_bases_string and custom_bases_string ~= "" then
+    -- Split by comma and loop
+    for custom_base_name in string.gmatch(custom_bases_string, '([^,]+)') do
+        custom_base_name = custom_base_name:match("^%s*(.-)%s*$") -- Trim extra whitespace
+        
+        if custom_base_name and custom_base_name ~= "" then
+            local base_entity = data.raw["spider-vehicle"][custom_base_name]
+            
+            if base_entity then
+                local custom_ctron_name = custom_base_name .. "-constructron"
+                
+                -- Dynamic Localised Name: "{Original Name} (Constructron)"
+                local ctron_localised_name = {"", {"entity-name." .. custom_base_name}, " (Constructron)"}
+                
+                -- Copy Entity
+                local new_entity = table.deepcopy(base_entity)
+                new_entity.name = custom_ctron_name
+                new_entity.minable.result = custom_ctron_name
+                new_entity.localised_name = ctron_localised_name
+                
+                data:extend({new_entity})
+                
+                -- Copy Item
+                local base_item = data.raw["item-with-entity-data"][custom_base_name] or data.raw["item"][custom_base_name]
+                if base_item then
+                    local new_item = table.deepcopy(base_item)
+                    new_item.name = custom_ctron_name
+                    new_item.place_result = custom_ctron_name
+                    new_item.localised_name = ctron_localised_name
+                    data:extend({new_item})
+                    
+                    -- Recipe (Create a recipe to turn the base vehicle into the constructron variant)
+                    local base_recipe = data.raw["recipe"][custom_base_name]
+                    if base_recipe then
+                        local new_recipe = {
+                            type = "recipe",
+                            name = custom_ctron_name,
+                            localised_name = ctron_localised_name,
+                            enabled = base_recipe.enabled,
+                            ingredients = {
+                                {type = "item", name = custom_base_name, amount = 1}
+                            },
+                            results = {
+                                {type = "item", name = custom_ctron_name, amount = 1}
+                            },
+                            energy = 1
+                        }
+                        data:extend({new_recipe})
+                        
+                        -- Add to technology if base recipe is unlocked via research
+                        for _, tech in pairs(data.raw["technology"]) do
+                            if tech.effects then
+                                for _, effect in pairs(tech.effects) do
+                                    if effect.type == "unlock-recipe" and effect.recipe == custom_base_name then
+                                        table.insert(tech.effects, {type = "unlock-recipe", recipe = custom_ctron_name})
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+
+                -- Add to Selection Tool Filters so Shift+Click works
+                local selection_tool = data.raw["selection-tool"]["ctron-selection-tool"]
+                if selection_tool and selection_tool.alt_select and selection_tool.alt_select.entity_filters then
+                    table.insert(selection_tool.alt_select.entity_filters, custom_ctron_name)
+                end
+            else
+                log("Constructron-Continued: Custom base entity '" .. custom_base_name .. "' not found. Could not generate custom constructron.")
+            end
+        end
+    end
+end

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -59,7 +59,7 @@ following_leader=Following the leader
 [ctron_gui_locale]
 all_logistics_req=All logistics requests
 main_title=Constructron Control Center
-station_label_caption=Service Station: 
+station_label_caption=Service Station:
 surface_selector_tooltip=Select a surface to view Constructron jobs. Only shows surfaces with at least one Constructron and one Service Station.
 settings=Settings
 debug_button_tooltip=Displays additional information around the map
@@ -79,7 +79,7 @@ job_card_destroy_name=Destroy Job
 job_card_utility_name=Utility Job
 job_card_minion_name=Minion Job
 job_status=Waiting for an available worker
-chunk_delay=Starting in __1__ seconds
+chunk_delay=Starting in 1 seconds
 job_locate_button=Locate
 job_locate_button_tooltip=Click to view job location(s)
 job_remote_button=Remote
@@ -92,7 +92,7 @@ main_no_jobs_label=No jobs
 all_logistics_button=All Logistics
 cargo_jobs_button=Cargo Jobs
 
-logistic_requests_label=Constructrons with requests: __1__
+logistic_requests_label=Constructrons with requests: 1
 
 settings_title=Constructron Settings
 settings_global_settings_label=Global Settings
@@ -141,7 +141,7 @@ job_worker_minimap_label=Worker location
 job_worker_minimap_tooltip=Click to follow worker
 job_job_minimap_label=Job location
 job_job_minimap_tooltip=Click to view job location(s)
-job_job_stat_tasks_label=Number of tasks: __1__
+job_job_stat_tasks_label=Number of tasks: 1
 job_worker_ammo_label=Ammunition
 job_worker_inventory_label=Inventory
 job_worker_logistic_trash_label=Logistic trash
@@ -189,3 +189,9 @@ item_already_requested=This item is already requested on this station.
 job_no_exist=This job no longer exists.
 job_finished=Job is already finishing.
 invalid_ammo=Invalid ammo selection.
+
+[mod-setting-name]
+custom-constructron-base=Custom Constructron Base Vehicles
+
+[mod-setting-description]
+custom-constructron-base=A comma-separated list of spidertron internal entity names (e.g., spidertron, kr-advanced-spidertron). The mod will automatically generate a Constructron variant for each of these!

--- a/script/command_functions.lua
+++ b/script/command_functions.lua
@@ -162,10 +162,44 @@ me.reacquire_stations = function()
     end
 end
 
-local ctron_entities = { "constructron", "constructron-rocket-powered" }
-if not prototypes.entity["constructron-rocket-powered"] then
-    ctron_entities = {"constructron"}
-end
+ local ctron_entities = setmetatable({}, {
+        __pairs = function()
+            local list = {}
+            if storage and storage.constructron_names then
+                for name in pairs(storage.constructron_names) do
+                    if prototypes.entity[name] then table.insert(list, name) end
+                end
+            end
+            return pairs(list)
+        end,
+        __ipairs = function()
+            local list = {}
+            if storage and storage.constructron_names then
+                for name in pairs(storage.constructron_names) do
+                    if prototypes.entity[name] then table.insert(list, name) end
+                end
+            end
+            return ipairs(list)
+        end,
+        __index = function(_, key)
+            local list = {}
+            if storage and storage.constructron_names then
+                for name in pairs(storage.constructron_names) do
+                    if prototypes.entity[name] then table.insert(list, name) end
+                end
+            end
+            return list[key]
+        end,
+        __len = function()
+            local list = {}
+            if storage and storage.constructron_names then
+                for name in pairs(storage.constructron_names) do
+                    if prototypes.entity[name] then table.insert(list, name) end
+                end
+            end
+            return #list
+        end
+    })
 
 me.reacquire_ctrons = function()
     for _, surface in pairs(game.surfaces) do

--- a/script/job.lua
+++ b/script/job.lua
@@ -310,12 +310,12 @@ function job:claim_chunks_in_proximity()
 end
 
 function job:move_to_position(position)
-    local worker = self.worker
+    local worker = self.worker ---@cast worker -nil
     if not worker or not worker.valid then return end
     local distance = util_func.distance_between(worker.position, position)
     worker.grid.inhibit_movement_bonus = (distance < 32)
 
-    if worker.name == "constructron-rocket-powered" then
+    if storage.flying_constructrons[worker.name] then
         pathfinder.set_autopilot(worker, { { position = position, needs_destroy_to_reach = false } })
         return
     end

--- a/settings.lua
+++ b/settings.lua
@@ -1,1 +1,10 @@
--- no game settings defined
+data:extend({
+    {
+        type = "string-setting",
+        name = "custom-constructron-base",
+        setting_type = "startup",
+        default_value = "",
+        allow_blank = true,
+        order = "z-a"
+    }
+})


### PR DESCRIPTION
added dynamic way to add custom constructron

- added on settings.lua an input field to add an entity name (spider-vehicle types) that you want to add as constructron -edited locale
-edited final-fixes, control and job.lua to accomodate the dynamic custom constructron feature