### PR TITLE
Update CC for Factorio 2.1 and hiding various bits from the player

### DIFF
--- a/data/constructron.lua
+++ b/data/constructron.lua
@@ -43,6 +43,7 @@ local constructron_recipe = {
     type = "recipe",
     name = "constructron",
     enabled = false,
+    categories = { "crafting" },
     ingredients = {
         {type = "item", name = "spidertron", amount = 1}
     },

--- a/data/constructron_pathing_proxy.lua
+++ b/data/constructron_pathing_proxy.lua
@@ -173,6 +173,7 @@ local template_entity = {
   icon_mipmaps = 0,
   flags = {"placeable-neutral", "not-on-map"},
   order = "z",
+  hidden = true,
   max_health = 1,
   render_layer = "object",
   collision_mask = pathing_collision_mask,

--- a/data/selection_tool.lua
+++ b/data/selection_tool.lua
@@ -4,6 +4,7 @@ data:extend(
             type = "selection-tool",
             name = "ctron-selection-tool",
             icons = {{ icon = "__Constructron-Continued__/graphics/icon_texture.png", icon_size = 128, mipmap_count = 2 }},
+            hidden = true,
             always_include_tiles = true,
             skip_fog_of_war = false,
             stack_size = 1,
@@ -36,7 +37,7 @@ data:extend(
             reverse_select = {
                 border_color = { r = 1 }, -- red
                 cursor_box_type = "entity",
-                mode = { "deconstruct", "items", "trees" }
+                mode = { "deconstruct", "items", "trees", "any-tile"  }
             },
 
             -- shift right click

--- a/data/service_station.lua
+++ b/data/service_station.lua
@@ -82,6 +82,7 @@ local service_station_recipe = {
     type = "recipe",
     name = "service_station",
     enabled = false,
+	categories = { "crafting" },
     ingredients = {
       {type = "item", name = "roboport", amount = 1}
     },

--- a/data/station_combinator.lua
+++ b/data/station_combinator.lua
@@ -5,5 +5,6 @@ station_combinator.selectable_in_game = false
 station_combinator.item_slot_count = 100
 station_combinator.draw_circuit_wires = false
 station_combinator.flags = { "hide-alt-info", "not-blueprintable", "not-on-map", }
-station_combinator.collision_mask = { layers = {}}
+station_combinator.collision_mask = { layers = {} }
+station_combinator.hidden = true
 data:extend({station_combinator})

--- a/info.json
+++ b/info.json
@@ -5,7 +5,7 @@
   "author": "ILLISIS",
   "homepage": "https://github.com/ILLISIS/Constructron-continued/",
   "description": "A spidertron that automatically moves, constructs, upgrades and/or deconstructs entities of any size, anywhere on the map with items from your logistic network for the ultimate fire and forget automation experience and unmatched scaling potential.",
-  "factorio_version": "2.0",
+  "factorio_version": "2.1",
   "dependencies": [
     "base >= 1.1.77",
     "! Constructron",


### PR DESCRIPTION
Hardly any changes are necessary, but since there are a few things i wanted hidden in the Factoriopedia/editor, i decided to make a quick PR anyhow.

The selection tool, constructron pathing proxy and station combinator are now hidden.

I did some basic testing to ensure building, up-/downgrading, decon, transport jobs, destroy jobs still work, so looks fine. All tests where done with both only base and full Spage, but i haven't done much beyond that.

Greetings
Der Failer